### PR TITLE
Makefile: use pkg-config for LDFLAGS, too

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,10 @@ BUILDHOST := $(patsubst CYGWIN_%,CYGWIN,$(BUILDHOST))
 
 ifneq ($(BUILDHOST),CYGWIN)
 CFLAGS = `pkg-config --cflags libusb-1.0`
+LDFLAGS = `pkg-config --libs libusb-1.0`
 else
 CFLAGS = -I/usr/include/libusb-1.0
+CFLAGS = -L/usr/lib -lusb-1.0
 endif
 
 %.o : %.cpp
@@ -16,7 +18,7 @@ endif
 	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(CFLAGS)
 
 imx_usb: imx_usb.o 
-	gcc -o $@ $@.o -lusb-1.0
+	gcc -o $@ $@.o $(LDFLAGS)
 
 clean:
 	rm -f imx_usb imx_usb.o


### PR DESCRIPTION
Signed-off-by: Marc Kleine-Budde <mkl@pengutronix.de>