### PR TITLE
Allow changing where the default configuration file is searched.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,12 +15,13 @@ else
 USBCFLAGS = -I/usr/include/libusb-1.0
 USBLDFLAGS = -L/usr/lib -lusb-1.0
 endif
+CONFCPPFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 
 imx_usb.o : imx_usb.c
-	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(USBCFLAGS) $(CFLAGS)
+	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(USBCFLAGS) $(CFLAGS) $(CONFCPPFLAGS)
 
 %.o : %.c
-	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(CFLAGS)
+	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(CFLAGS) $(CONFCPPFLAGS)
 
 imx_usb: imx_usb.o imx_sdp.o
 	$(CC) -o $@ $@.o imx_sdp.o $(LDFLAGS) $(USBLDFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 all: imx_usb imx_uart
 
-DESTDIR ?= ""
-prefix ?= "/usr"
-bindir ?= "$(prefix)/bin"
-sysconfdir ?= "$(prefix)/etc"
+DESTDIR ?=
+prefix ?= /usr
+bindir ?= $(prefix)/bin
+sysconfdir ?= $(prefix)/etc
 
 BUILDHOST := $(shell uname -s)
 BUILDHOST := $(patsubst CYGWIN_%,CYGWIN,$(BUILDHOST))
@@ -29,11 +29,11 @@ imx_uart: imx_uart.o imx_sdp.o
 	$(CC) -o $@ $@.o imx_sdp.o $(LDFLAGS)
 
 install: imx_usb imx_uart
-	mkdir -p $(DESTDIR)$(sysconfdir)/imx-loader.d/
-	install -m644 *.conf $(DESTDIR)$(sysconfdir)/imx-loader.d/
-	mkdir -p $(DESTDIR)$(bindir)
-	install -m755 imx_usb $(DESTDIR)$(bindir)/imx_usb
-	install -m755 imx_uart $(DESTDIR)$(bindir)/imx_uart
+	mkdir -p '$(DESTDIR)$(sysconfdir)/imx-loader.d/'
+	install -m644 *.conf '$(DESTDIR)$(sysconfdir)/imx-loader.d/'
+	mkdir -p '$(DESTDIR)$(bindir)'
+	install -m755 imx_usb '$(DESTDIR)$(bindir)/imx_usb'
+	install -m755 imx_uart '$(DESTDIR)$(bindir)/imx_uart'
 
 clean:
 	rm -f imx_usb imx_uart imx_usb.o imx_uart.o imx_sdp.o

--- a/imx_uart.c
+++ b/imx_uart.c
@@ -378,7 +378,7 @@ int main(int argc, char * const argv[])
 		conffile++; // Filename starts after slash
 	}
 
-	conf = conf_file_name(conffile, basepath, "/etc/imx-loader.d/");
+	conf = conf_file_name(conffile, basepath, SYSCONFDIR "/imx-loader.d/");
 	if (conf == NULL)
 		return -1;
 

--- a/imx_usb.c
+++ b/imx_usb.c
@@ -420,7 +420,7 @@ int main(int argc, char * const argv[])
 	struct sdp_work *cmd_head = NULL;
 	char const *conf;
 	char const *base_path = get_base_path(argv[0]);
-	char const *conf_path = "/etc/imx-loader.d/";
+	char const *conf_path = SYSCONFDIR "/imx-loader.d/";
 
 	err = parse_opts(argc, argv, &conf_path, &verify, &cmd_head);
 	if (err < 0)


### PR DESCRIPTION
The configuration file is always searched in /etc, regardless of the Makefile's PREFIX and sysconfdir settings. The second patch makes it look for it in the proper location: $(sysconfdir).  The first is a small Makefile fix which is needed for proper sysconfdir quoting.