### PR TITLE
imx_sdp: improve config search order

### DIFF
--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -153,15 +153,15 @@ char const *conf_file_name(char const *file, char const *base_path, char const *
 {
 	char const *conf;
 
-	// First priority, base path, relative path of binary...
-	dbg_printf("checking with base_path %s\n", base_path);
-	conf = conf_path_ok(base_path, file);
+	// First priority, conf path... (either -c, binary or /etc/imx-loader.d/)
+	dbg_printf("checking with conf_path %s\n", conf_path);
+	conf = conf_path_ok(conf_path, file);
 	if (conf != NULL)
 		return conf;
 
-	// Second priority, conf path... (either -c, binary or /etc/imx-loader.d/)
-	dbg_printf("checking with conf_path %s\n", conf_path);
-	conf = conf_path_ok(conf_path, file);
+	// Second priority, base path, relative path of binary...
+	dbg_printf("checking with base_path %s\n", base_path);
+	conf = conf_path_ok(base_path, file);
 	if (conf != NULL)
 		return conf;
 


### PR DESCRIPTION
merge request as discussed on https://github.com/boundarydevices/imx_usb_loader/issues/10#issuecomment-97449167. better late than never!

if you don't have write-access to /etc/imx-loader.d and want to override
settings there, for example, this is impossible if base-path takes
precedence.

giving user-specified config paths first priority may avoid such
situations.

