### PR TITLE
Fix segfault on plugin load

### DIFF
--- a/imx_usb.c
+++ b/imx_usb.c
@@ -323,6 +323,7 @@ libusb_device_handle * open_vid_pid(struct mach_id *mach, struct sdp_dev *p_id)
 		printf("claim failed, err=%i\n", err);
 		goto err2;
 	}
+	p_id->priv = h;
 	err = do_status(p_id);
 	if (!err)
 		return h;


### PR DESCRIPTION
When re-connecting to the board after loading a plugin, the libusb handle
was not updated and this stale pointer caused a segfault.
With this patch, uploading and booting plugin+uboot images works as intended, tested with our plugin that we opensourced at https://github.com/ArtecDesign/imx-plugin 

Signed-off-by: Anti Sullin <anti.sullin@artecdesign.ee>