### PR TITLE
imx_sdp: Change DCD OCRAM address to match Freescale tools

### DIFF
--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -677,7 +677,7 @@ static int write_dcd(struct sdp_dev *dev, struct ivt_header *hdr, unsigned char 
 {
 	struct sdp_command dl_command = {
 		.cmd = SDP_WRITE_DCD,
-		.addr = BE32(0x914000),
+		.addr = BE32(0x910000),
 		.format = 0,
 		.cnt = 0,
 		.data = 0,


### PR DESCRIPTION
With the current OCRAM address for DCD used in imx_usb, a bootloader would need to be signed twice with different configurations to support both imx_usb (address 0x914000) and the Freescale MfgTool (address 0x910000) when using High Assurance Boot (HAB).

Updated the OCRAM address where the DCD is loaded so if a bootloader is signed, it can be loaded with both Freescale tools (MfgTool) and the imx_usb program without needing to be signed twice.