### PR TITLE
Compiles on Ubuntu 14.04 x64

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,13 @@ USBLDFLAGS = -L/usr/lib -lusb-1.0
 endif
 CONFCPPFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
 
+CFLAGS=-D_BSD_SOURCE -std=c99 -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb
+
 imx_usb.o : imx_usb.c imx_sdp.h portable.h
-	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(USBCFLAGS) $(CFLAGS) $(CONFCPPFLAGS)
+	$(CC) -c $*.c -o $@ $(USBCFLAGS) $(CFLAGS) $(CONFCPPFLAGS)
 
 %.o : %.c imx_sdp.h portable.h
-	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(CFLAGS) $(CONFCPPFLAGS)
+	$(CC) -c $*.c -o $@ $(CFLAGS) $(CONFCPPFLAGS)
 
 imx_usb: imx_usb.o imx_sdp.o
 	$(CC) -o $@ $@.o imx_sdp.o $(LDFLAGS) $(USBLDFLAGS)


### PR DESCRIPTION
This patch makes it compile successfully on Ubuntu 14.04 for x86. There are two changes: -std=c99 is specified (as the code is C99 compliant) and _BSD_SOURCE is defined to pull in the usleep function.