### PR TITLE
Make project buildable on FreeBSD

### DIFF
--- a/imx_usb.c
+++ b/imx_usb.c
@@ -29,7 +29,11 @@
 #include <stdint.h>
 #include <getopt.h>
 
+#ifdef __FreeBSD__
+#include <libusb.h>
+#else
 #include <libusb-1.0/libusb.h>
+#endif
 
 #include "portable.h"
 #include "imx_sdp.h"

--- a/portable.h
+++ b/portable.h
@@ -21,10 +21,13 @@ extern int debugmode;
 #include <Windows.h>
 #include <direct.h>
 #include <io.h>
-#else
+#endif
+#ifdef __linux__
 #include <linux/limits.h>
 #endif
-
+#ifdef __FreeBSD__
+#include <sys/param.h>
+#endif
 
 #ifndef WIN32
 #define PATH_SEPARATOR '/'


### PR DESCRIPTION
- On FreeBSD libusb is part of the base OS, so it doesn't have versioned
    dir in include
- Include sys/param.h for PATH_MAX on FreeBSD

This patch was tested with iMX7 on FreeBSD 12