### PR TITLE
Improve work handling

### DIFF
--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -131,6 +131,14 @@ struct flash_header_v1 {
 	uint32_t app_dest_ptr;
 };
 
+static const char *jump_modes[] = {
+	[J_UNKNOWN] = "unknown",
+	[J_ADDR_DIRECT] = "addr_direct",
+	[J_ADDR_HEADER] = "addr_header",
+	[J_HEADER] = "header",
+	[J_HEADER2] = "header2",
+};
+
 static void print_sdp_work(const struct sdp_work *curr)
 {
 	printf("== work item\n");
@@ -141,7 +149,10 @@ static void print_sdp_work(const struct sdp_work *curr)
 	printf("dcd %u\n", curr->dcd);
 	printf("clear_dcd %u\n", curr->clear_dcd);
 	printf("plug %u\n", curr->plug);
-	printf("jump_mode %d\n", curr->jump_mode);
+	if (curr->jump_mode <= J_HEADER2)
+		printf("jump_mode %s\n", jump_modes[curr->jump_mode]);
+	else
+		printf("jump_mode %s\n", "unknown");
 	printf("jump_addr 0x%08x\n", curr->jump_addr);
 	printf("== end work item\n");
 	return;

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -134,6 +134,7 @@ struct flash_header_v1 {
 static void print_sdp_work(struct sdp_work *curr)
 {
 	printf("== work item\n");
+	printf("memory work %s\n", curr->mem ? "yes" : "no");
 	printf("filename %s\n", curr->filename);
 	printf("load_size %d bytes\n", curr->load_size);
 	printf("load_addr 0x%08x\n", curr->load_addr);
@@ -1387,7 +1388,6 @@ static int do_download(struct sdp_dev *dev, struct sdp_work *curr, int verify)
 	int ret;
 	struct load_desc ld = {};
 
-	print_sdp_work(curr);
 	ld.curr = curr;
 	ld.verify = verify;
 	ld.xfile = fopen(curr->filename, "rb" );
@@ -1473,6 +1473,7 @@ int do_work(struct sdp_dev *p_id, struct sdp_work **work, int verify)
 
 	while (curr) {
 		/* Do current job */
+		print_sdp_work(curr);
 		if (curr->mem)
 			perform_mem_work(p_id, curr->mem);
 		if (curr->filename[0])

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -64,6 +64,10 @@ struct load_desc {
 	unsigned char writeable_header[1024];
 };
 
+/* Boot data image indicator */
+#define PLUGIN_IMAGE_FLAG_MASK              (0x0001)    /* bit 0 is plugin */
+#define HDMI_IMAGE_FLAG_MASK                (0x0002)    /* bit 1 is HDMI */
+
 struct boot_data {
 	uint32_t dest;
 	uint32_t image_len;
@@ -1314,7 +1318,7 @@ static int process_header(struct sdp_dev *dev, struct sdp_work *curr,
 				return ret;
 			}
 		}
-		if (ld->plugin == 2) {
+		if (ld->plugin & HDMI_IMAGE_FLAG_MASK) {
 			if (!hdmi_ivt) {
 				hdmi_ivt++;
 				header_inc = 0x1c00 - 0x1000 + ld->max_length;
@@ -1332,7 +1336,7 @@ static int process_header(struct sdp_dev *dev, struct sdp_work *curr,
 			header_max = ld->header_offset + header_inc + 0x400;
 			continue;
 		}
-		if (ld->plugin && (!curr->plug) && (!header_cnt)) {
+		if ((ld->plugin & PLUGIN_IMAGE_FLAG_MASK) && (!curr->plug) && (!header_cnt)) {
 			header_cnt++;
 			header_max = ld->header_offset + ld->max_length + 0x400;
 			printf("header_max=%x\n", header_max);

--- a/imx_sdp.h
+++ b/imx_sdp.h
@@ -46,6 +46,7 @@ struct sdp_work {
 	unsigned char clear_dcd;		//means clear dcd_ptr
 	unsigned char clear_boot_data;		//means clear boot data ptr
 	unsigned char plug;
+#define J_UNKNOWN	0
 #define J_ADDR_DIRECT	1
 #define J_ADDR_HEADER	2
 #define J_HEADER	3

--- a/mx6_usb_work.conf
+++ b/mx6_usb_work.conf
@@ -12,6 +12,9 @@ hid,1024,0x910000,0x10000000,1G,0x00900000,0x40000
 #     This does not build a header like jump nnn will.
 #plug - without jump uses header but clears plug flag to stop after plug execution
 #load nnn - load entire file to address
+tests/test-plugin.imx:plug
+#tests/test-plugin.imx:load
+#tests/test-plugin.imx:jump header
 #size nnn - limit file size to load
 #skip nnn - ignore the 1st nnn bytes from file
 #../u-boot-imx6/u-boot.bin:dcd,plug,jump header

--- a/tests/test-dcd.imx.output
+++ b/tests/test-dcd.imx.output
@@ -28,6 +28,7 @@ report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
 == work item
+memory work no
 filename test-dcd.imx
 load_size 0 bytes
 load_addr 0x00000000

--- a/tests/test-plugin.imx.output
+++ b/tests/test-plugin.imx.output
@@ -28,6 +28,7 @@ report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
 == work item
+memory work no
 filename test-plugin.imx
 load_size 0 bytes
 load_addr 0x00000000

--- a/tests/test-plugin.imx.output
+++ b/tests/test-plugin.imx.output
@@ -9196,17 +9196,7 @@ cmd: 0505
 report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
-== work item
-filename test-plugin.imx
-load_size 0 bytes
-load_addr 0x00000000
-dcd 0
-clear_dcd 0
-plug 0
-jump_mode 3
-jump_addr 0x00000000
-== end work item
-header_max=10400
+header_max=10000
 
 loading binary file(test-plugin.imx) to 877effd4, skip=0, fsize=1102c type=aa
 report=1, cnt=16

--- a/tests/test.imx.output
+++ b/tests/test.imx.output
@@ -28,6 +28,7 @@ report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
 == work item
+memory work no
 filename test.imx
 load_size 0 bytes
 load_addr 0x00000000


### PR DESCRIPTION
This removes some rather complex interactions across do_work/do_download/process_header. The tests run still fine, and I tested the patchset using imx_usb, in batch mode and without on i.MX 6/7 and imx_uart on Vybrid. We do not use plugin mode, so this has only been covered through the simulation/testing.