### PR TITLE
[RFC] i.MX8QM/QX support v1

### DIFF
--- a/imx_loader_config.c
+++ b/imx_loader_config.c
@@ -343,6 +343,13 @@ void parse_transfer_type(struct sdp_dev *usb, const char *filename, const char *
 	}
 	usb->max_transfer = get_val(&p, 10);
 	p = skip(p,',');
+	if (strncmp(p, "max_dcd", 7) == 0) {
+		p += 7;
+		usb->max_dcd_size = get_val(&p, 10);
+		p = skip(p,',');
+	} else {
+		usb->max_dcd_size = HAB_MAX_DCD_SIZE_DEFAULT;
+	}
 	usb->dcd_addr = get_val(&p, 16);
 	p = skip(p,',');
 	for (i = 0; i < 8; i++) {

--- a/imx_loader_config.c
+++ b/imx_loader_config.c
@@ -338,6 +338,14 @@ void parse_transfer_type(struct sdp_dev *usb, const char *filename, const char *
 		p += 12;
 		p = skip(p,',');
 		usb->header_type = HDR_UBOOT;
+	} else if (strncmp(p, "imx8qm", 6) == 0) {
+		p += 6;
+		p = skip(p,',');
+		usb->header_type = HDR_MX8QM;
+	} else if (strncmp(p, "imx8qx", 6) == 0) {
+		p += 6;
+		p = skip(p,',');
+		usb->header_type = HDR_MX8QX;
 	} else {
 		usb->header_type = HDR_MX53;
 	}

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -464,6 +464,42 @@ static int write_dcd(struct sdp_dev *dev, struct dcd_v2 *dcd)
 	return transferSize;
 }
 
+static int do_skip_ddr(struct sdp_dev *dev)
+{
+	int err;
+	struct sdp_command skip_dcd_command = {
+		.cmd = SDP_SKIP_DCD,
+		.addr = 0,
+		.format = 0,
+		.cnt = 0,
+		.data = 0,
+		.rsvd = 0x00};
+	unsigned int sec, status;
+
+	printf("skipping DCD\n");
+	err = do_command(dev, &skip_dcd_command, 5);
+	if (err)
+		return err;
+
+	err = do_response(dev, 3, &sec, false);
+	if (err)
+		return err;
+
+	err = do_response(dev, 4, &status, false);
+	if (err) {
+		printf("failed (security 0x%08x, status 0x%08x)\n", sec, status);
+		return err;
+	}
+
+	printf("skip DCD ");
+	if (status == BE32(0x900DD009UL))
+		printf("succeeded\n");
+	else
+		printf("failed\n");
+
+	return 0;
+}
+
 static int write_dcd_table_ivt(struct sdp_dev *dev, struct dcd_v2 *dcdhdr)
 {
 	int length = BE16(dcdhdr->header.length);

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -131,6 +131,14 @@ struct flash_header_v1 {
 	uint32_t app_dest_ptr;
 };
 
+static const char *jump_modes[] = {
+	[J_UNKNOWN] = "unknown",
+	[J_ADDR_DIRECT] = "addr_direct",
+	[J_ADDR_HEADER] = "addr_header",
+	[J_HEADER] = "header",
+	[J_HEADER2] = "header2",
+};
+
 static void print_sdp_work(const struct sdp_work *curr)
 {
 	printf("== work item\n");
@@ -141,7 +149,10 @@ static void print_sdp_work(const struct sdp_work *curr)
 	printf("dcd %u\n", curr->dcd);
 	printf("clear_dcd %u\n", curr->clear_dcd);
 	printf("plug %u\n", curr->plug);
-	printf("jump_mode %d\n", curr->jump_mode);
+	if (curr->jump_mode <= J_HEADER2)
+		printf("jump_mode %s\n", jump_modes[curr->jump_mode]);
+	else
+		printf("jump_mode %s\n", "unknown");
 	printf("jump_addr 0x%08x\n", curr->jump_addr);
 	printf("== end work item\n");
 	return;

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -134,6 +134,7 @@ struct flash_header_v1 {
 static void print_sdp_work(struct sdp_work *curr)
 {
 	printf("== work item\n");
+	printf("memory work %s\n", curr->mem ? "yes" : "no");
 	printf("filename %s\n", curr->filename);
 	printf("load_size %d bytes\n", curr->load_size);
 	printf("load_addr 0x%08x\n", curr->load_addr);
@@ -1387,7 +1388,6 @@ static int do_download(struct sdp_dev *dev, struct sdp_work *curr, int verify)
 	int ret;
 	struct load_desc ld = {};
 
-	print_sdp_work(curr);
 	ld.curr = curr;
 	ld.verify = verify;
 	ld.xfile = fopen(curr->filename, "rb" );
@@ -1473,6 +1473,7 @@ int do_work(struct sdp_dev *p_id, struct sdp_work **work, int verify)
 
 	while (curr) {
 		/* Do current job */
+		print_sdp_work(curr);
 		if (curr->mem)
 			perform_mem_work(p_id, curr->mem);
 		if (curr->filename[0])

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -64,6 +64,10 @@ struct load_desc {
 	unsigned char writeable_header[1024];
 };
 
+/* Boot data image indicator */
+#define PLUGIN_IMAGE_FLAG_MASK              (0x0001)    /* bit 0 is plugin */
+#define HDMI_IMAGE_FLAG_MASK                (0x0002)    /* bit 1 is HDMI */
+
 struct boot_data {
 	uint32_t dest;
 	uint32_t image_len;
@@ -1314,7 +1318,7 @@ static int process_header(struct sdp_dev *dev, struct sdp_work *curr,
 				return ret;
 			}
 		}
-		if (ld->plugin == 2) {
+		if (ld->plugin & HDMI_IMAGE_FLAG_MASK) {
 			if (!hdmi_ivt) {
 				hdmi_ivt++;
 				header_inc = 0x1c00 - 0x1000 + ld->max_length;
@@ -1332,7 +1336,7 @@ static int process_header(struct sdp_dev *dev, struct sdp_work *curr,
 			header_max = ld->header_offset + header_inc + 0x400;
 			continue;
 		}
-		if (ld->plugin && (!curr->plug) && (!header_cnt)) {
+		if ((ld->plugin & PLUGIN_IMAGE_FLAG_MASK) && (!curr->plug) && (!header_cnt)) {
 			header_cnt++;
 			header_max = ld->header_offset + ld->max_length + 0x400;
 			printf("header_max=%x\n", header_max);

--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -424,7 +424,7 @@ static int write_dcd(struct sdp_dev *dev, struct dcd_v2 *dcd)
 	int err;
 	unsigned transferSize=0;
 
-	if (length > HAB_MAX_DCD_SIZE) {
+	if (length > dev->max_dcd_size) {
 		printf("DCD is too big (%d bytes)\n", length);
 		return -1;
 	}

--- a/imx_sdp.h
+++ b/imx_sdp.h
@@ -46,6 +46,7 @@ struct sdp_work {
 	unsigned char clear_dcd;		//means clear dcd_ptr
 	unsigned char clear_boot_data;		//means clear boot data ptr
 	unsigned char plug;
+#define J_UNKNOWN	0
 #define J_ADDR_DIRECT	1
 #define J_ADDR_HEADER	2
 #define J_HEADER	3

--- a/imx_sdp.h
+++ b/imx_sdp.h
@@ -70,6 +70,7 @@ struct sdp_dev {
 #define HDR_UBOOT	3
 	unsigned char header_type;
 	unsigned dcd_addr;
+	unsigned max_dcd_size;
 	struct ram_area ram[8];
 	struct sdp_work *work;
 	/*
@@ -92,7 +93,7 @@ struct sdp_dev {
  * Section 8.7.2 of the i.MX6DQ/UL/SoloX RM:
  * The maximum size of the DCD limited to 1768 bytes.
  */
-#define HAB_MAX_DCD_SIZE 1768
+#define HAB_MAX_DCD_SIZE_DEFAULT 1768
 
 #define SDP_READ_REG     0x0101
 #define SDP_WRITE_REG    0x0202

--- a/imx_sdp.h
+++ b/imx_sdp.h
@@ -101,6 +101,7 @@ struct sdp_dev {
 #define SDP_ERROR_STATUS 0x0505
 #define SDP_WRITE_DCD    0x0a0a
 #define SDP_JUMP_ADDRESS 0x0b0b
+#define SDP_SKIP_DCD     0x0c0c
 
 #pragma pack (1)
 struct sdp_command {

--- a/imx_sdp.h
+++ b/imx_sdp.h
@@ -67,7 +67,9 @@ struct sdp_dev {
 #define HDR_NONE	0
 #define HDR_MX51	1
 #define HDR_MX53	2
-#define HDR_UBOOT	3
+#define HDR_MX8QM	3
+#define HDR_MX8QX	4
+#define HDR_UBOOT	5
 	unsigned char header_type;
 	unsigned dcd_addr;
 	unsigned max_dcd_size;
@@ -113,6 +115,8 @@ struct sdp_command {
 	uint8_t rsvd;
 };
 #pragma pack ()
+
+#define IVT_OFFSET_SD           (0x400)
 
 void dump_long(unsigned char *src, unsigned cnt, unsigned addr, unsigned skip);
 void dump_bytes(unsigned char *src, unsigned cnt, unsigned addr);

--- a/imx_usb.conf
+++ b/imx_usb.conf
@@ -18,3 +18,5 @@
 0x1b67:0x4fff, mx6_usb_sdp_spl.conf
 0x0525:0xb4a4, mx6_usb_sdp_spl.conf
 0x1fc9:0x012b, mx8mq_usb_work.conf
+0x1fc9:0x0129, mx8qm_usb_work.conf
+0x1fc9:0x012f, mx8qx_usb_work.conf

--- a/mx6_usb_work.conf
+++ b/mx6_usb_work.conf
@@ -12,6 +12,9 @@ hid,1024,0x910000,0x10000000,1G,0x00900000,0x40000
 #     This does not build a header like jump nnn will.
 #plug - without jump uses header but clears plug flag to stop after plug execution
 #load nnn - load entire file to address
+tests/test-plugin.imx:plug
+#tests/test-plugin.imx:load
+#tests/test-plugin.imx:jump header
 #size nnn - limit file size to load
 #skip nnn - ignore the 1st nnn bytes from file
 #../u-boot-imx6/u-boot.bin:dcd,plug,jump header

--- a/mx8mq_usb_work.conf
+++ b/mx8mq_usb_work.conf
@@ -1,6 +1,6 @@
 mx8_qsb
 #hid/bulk,[old_header,]max packet size, dcd_addr, {ram start, ram size}(repeat valid ram areas)
-hid,1024,0x910000,0x40000000,1G,0x00900000,0x40000
+hid,1024,max_dcd 8144,0x910000,0x40000000,1G,0x00900000,0x40000
 #load/run SPL
 ../imx-mkimage/iMX8M/flash.bin:dcd,clear_dcd,plug,jump header
 #0x60000 - 0x8400 = 0x57c00, +0x3000=5ac00 (FIT image)

--- a/mx8qm_usb_work.conf
+++ b/mx8qm_usb_work.conf
@@ -1,0 +1,33 @@
+mx8qm
+#hid/bulk,[old_header,]max packet size,[max_dcd nnn,] dcd_addr, {ram start, ram size}(repeat valid ram areas)
+#hid,1024,0x910000,0x10000000,1G,0x00900000,0x40000,0x30fe0000,0x20000
+hid,imx8qm,1024,max_dcd 2880,0x2000e400,0x20000,0x910000,0x10000000,1G,0x30fe0000,0x40000
+#file:dcd,plug,load nnn,jump [nnn/header/header2]
+#jump nnn - header is after last downloaded word
+#            entire file is loaded before jump, needs load nnn as well
+# i.e. file:load nnn,jump nnn
+#jump header - only length parameter is downloaded
+#header - uses existing header(error if none), but clears plug and dcd values unless plug also specified
+#header2 - uses 2nd header found(error if none)
+#plug - without jump uses header but clears plug flag to stop after plug execution
+#load nnn - load entire file to address
+#../u-boot-imx6/u-boot.bin:dcd,plug,jump header
+#:modify,020e02a8,7,1
+#:modify,020e00bc,7,4
+#:read,020e02a8
+#:read,020e00bc
+#:read,020c4078
+#:modify,020c407c,0,0f000000
+#:modify,020c4080,0,c00
+#:read,020c4084
+#../imx_utils/mx6_ddr_init_xm.bin:dcd
+#../u-boot-imx6/u-boot.bin:load 0x13effc00
+#../u-boot-imx6/u-boot.imx:load 0x13f00000
+#../u-boot-dirk/u-boot.imx:load 0x13f00000
+#u-boot-6w.bin:load 0x13effc00
+#u-boot_1103.bin:load 0x13effc00
+#u-boot_1103.bin:jump header
+#./iMX8QM/scfw_tcm.bin:load 0x30fe0000,jump 0x1ffe0000
+#./iMX8QM/scfw_tcm.bin:load 0x1ffe0000
+#../imx_utils/mx6_ecspi_ram_write_xm.bin:clear_dcd,plug
+#../imx6_obds/output/mx61/bin/diag-obds-mx61qsb-rev1.bin:jump header

--- a/mx8qx_usb_work.conf
+++ b/mx8qx_usb_work.conf
@@ -1,0 +1,33 @@
+mx8
+#hid/bulk,[old_header,]max packet size, dcd_addr, {ram start, ram size}(repeat valid ram areas)
+#hid,1024,0x910000,0x10000000,1G,0x00900000,0x40000,0x30fe0000,0x20000
+hid,imx8qx,1024,max_dcd 2880,0x2000e400,0x20000,0x910000,0x10000000,1G,0x30fe0000,0x40000
+#file:dcd,plug,load nnn,jump [nnn/header/header2]
+#jump nnn - header is after last downloaded word
+#            entire file is loaded before jump, needs load nnn as well
+# i.e. file:load nnn,jump nnn
+#jump header - only length parameter is downloaded
+#header - uses existing header(error if none), but clears plug and dcd values unless plug also specified
+#header2 - uses 2nd header found(error if none)
+#plug - without jump uses header but clears plug flag to stop after plug execution
+#load nnn - load entire file to address
+#../u-boot-imx6/u-boot.bin:dcd,plug,jump header
+#:modify,020e02a8,7,1
+#:modify,020e00bc,7,4
+#:read,020e02a8
+#:read,020e00bc
+#:read,020c4078
+#:modify,020c407c,0,0f000000
+#:modify,020c4080,0,c00
+#:read,020c4084
+#../imx_utils/mx6_ddr_init_xm.bin:dcd
+#../u-boot-imx6/u-boot.bin:load 0x13effc00
+#../u-boot-imx6/u-boot.imx:load 0x13f00000
+#../u-boot-dirk/u-boot.imx:load 0x13f00000
+#u-boot-6w.bin:load 0x13effc00
+#u-boot_1103.bin:load 0x13effc00
+#u-boot_1103.bin:jump header
+#./iMX8QM/scfw_tcm.bin:load 0x30fe0000,jump 0x1ffe0000
+#./iMX8QM/scfw_tcm.bin:load 0x1ffe0000
+#../imx_utils/mx6_ecspi_ram_write_xm.bin:clear_dcd,plug
+#../imx6_obds/output/mx61/bin/diag-obds-mx61qsb-rev1.bin:jump header

--- a/tests/test-dcd.imx.output
+++ b/tests/test-dcd.imx.output
@@ -28,6 +28,7 @@ report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
 == work item
+memory work no
 filename test-dcd.imx
 load_size 0 bytes
 load_addr 0x00000000

--- a/tests/test-plugin.imx.output
+++ b/tests/test-plugin.imx.output
@@ -28,6 +28,7 @@ report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
 == work item
+memory work no
 filename test-plugin.imx
 load_size 0 bytes
 load_addr 0x00000000

--- a/tests/test-plugin.imx.output
+++ b/tests/test-plugin.imx.output
@@ -9196,17 +9196,7 @@ cmd: 0505
 report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
-== work item
-filename test-plugin.imx
-load_size 0 bytes
-load_addr 0x00000000
-dcd 0
-clear_dcd 0
-plug 0
-jump_mode 3
-jump_addr 0x00000000
-== end work item
-header_max=10400
+header_max=10000
 
 loading binary file(test-plugin.imx) to 877effd4, skip=0, fsize=1102c type=aa
 report=1, cnt=16

--- a/tests/test.imx.output
+++ b/tests/test.imx.output
@@ -28,6 +28,7 @@ report=3, cnt=64
 HAB security state: development mode (0x56787856)
 report=4, cnt=64
 == work item
+memory work no
 filename test.imx
 load_size 0 bytes
 load_addr 0x00000000


### PR DESCRIPTION
This is a first draft on how to implement i.MX8QM/i.MX8QX support. It skips the rather complex image parsing code and uses a separate image parsing functions. Due to different layout there are currently two functions used, but this should be simplified. The fiel download function is at this point also duplicated for simplicity reasons. For the actual DCD download/skip DCD and jump command functions are reused.