### PR TITLE
portable.h: fix build with gcc older than 4.8

### DIFF
--- a/portable.h
+++ b/portable.h
@@ -58,7 +58,11 @@ extern int debugmode;
 #ifdef __GNUC__
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 #define BE32(x) __builtin_bswap32(x)
-#define BE16(x) __builtin_bswap16(x)
+#define BE16(x) \
+({ \
+	typeof(x) __x = (x); \
+	(__x<<8 | __x>>8); \
+})
 #else
 #define BE32(x) x
 #define BE16(x) x


### PR DESCRIPTION
__builtin_bswap16 is available in all gcc architectures only since
version 4.8. Older gcc versions fail to build:

imx_sdp.o: In function `perform_dcd':
.../imx_sdp.c:1138: undefined reference to `__builtin_bswap16'
imx_sdp.o: In function `write_dcd_table_ivt':
.../imx_sdp.c:457: undefined reference to `__builtin_bswap16'
imx_sdp.o: In function `write_dcd':
.../imx_sdp.c:410: undefined reference to `__builtin_bswap16'
imx_sdp.o: In function `init_header':
.../imx_sdp.c:1075: undefined reference to `__builtin_bswap16'

Use a local implementation instead.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>