### PR TITLE
imx_usb: use device found by find_imx_device

### DIFF
--- a/imx_usb.c
+++ b/imx_usb.c
@@ -504,7 +504,7 @@ int do_autodetect_dev(char const *base_path, char const *conf_path,
 		printf("Trying to open device vid=0x%04x pid=0x%04x", mach->vid, mach->pid);
 		fflush(stdout);
 		for (retry = 0; retry < 50; retry++) {
-			h = libusb_open_device_with_vid_pid(NULL, mach->vid, mach->pid);
+			err = libusb_open(dev, &h);
 			if (h)
 				break;
 


### PR DESCRIPTION
This will allow the use of imx_usb for several devices at the same time with the same VID:PID if used with the --address option.