### PR TITLE
Build: add missing files in the Makefile for Mingw

### DIFF
--- a/Makefile.mingw
+++ b/Makefile.mingw
@@ -4,19 +4,19 @@ all: imx_usb imx_uart
 
 # Building with MinGW natively
 CC = gcc
-USBCFLAGS = -I$(LIBUSBPATH)\include
-USBLDFLAGS = -L$(LIBUSBPATH)\MinGW32\dll -lusb-1.0
+USBCFLAGS = -I$(LIBUSBPATH)/include
+USBLDFLAGS = -L$(LIBUSBPATH)/MinGW32/dll -lusb-1.0
 
-imx_usb.o : imx_usb.c imx_sdp.h portable.h
+imx_usb.o : imx_usb.c imx_sdp.h imx_loader_config.h portable.h
 	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(USBCFLAGS) $(CFLAGS)
 
-%.o : %.c imx_sdp.h portable.h
+%.o : %.c imx_sdp.h imx_loader_config.h portable.h image.h
 	$(CC) -c $*.c -o $@ -Wstrict-prototypes -Wno-trigraphs -pipe -ggdb $(CFLAGS)
 
-imx_usb: imx_usb.o imx_sdp.o
+imx_usb: imx_usb.o imx_sdp.o imx_sdp_simulation.o imx_loader_config.o
 	$(CC) -o $@ $@.o imx_sdp.o $(LDFLAGS) $(USBLDFLAGS)
 
-imx_uart: imx_uart.o imx_sdp.o
+imx_uart: imx_uart.o imx_sdp.o imx_loader_config.o
 	$(CC) -o $@ $@.o imx_sdp.o $(LDFLAGS)
 
 clean:


### PR DESCRIPTION
Did some modification in Makefile.mingw.

For my personal usage, I also changed the `MINGW32` to `MINGW64` for linking with the objects generated  by mingw-w64 toolchain in MSYS2 environment.

But in this pull request, I leave the `MINGW32` unchanged. 

Maybe it's a good idea that to add one more variable for 32-bit or 64bit selection. 