### PR TITLE
Fixed MSVC build for imx_uart and created .conf for i.MX6UL

### DIFF
--- a/imx_sdp.c
+++ b/imx_sdp.c
@@ -1363,7 +1363,7 @@ static int process_header(struct sdp_dev *dev, struct sdp_work *curr,
 static int do_download(struct sdp_dev *dev, struct sdp_work *curr, int verify)
 {
 	int ret;
-	struct load_desc ld = {};
+	struct load_desc ld = { 0 };
 
 	print_sdp_work(curr);
 	ld.curr = curr;

--- a/msvc/imx_uart.vcxproj
+++ b/msvc/imx_uart.vcxproj
@@ -88,11 +88,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\imx_loader_config.c" />
     <ClCompile Include="..\imx_sdp.c" />
     <ClCompile Include="..\imx_uart.c" />
     <ClCompile Include="getopt.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\imx_loader_config.h" />
     <ClInclude Include="..\imx_sdp.h" />
     <ClInclude Include="..\portable.h" />
     <ClInclude Include="getopt.h" />

--- a/mx6ul_uart_work.conf
+++ b/mx6ul_uart_work.conf
@@ -1,0 +1,3 @@
+mx6ul
+#hid/bulk,[old_header,]max packet size, dcd_addr, {ram start, ram size}(repeat valid ram areas)
+hid,1024,0x910000,0x80000000,512M,0x00900000,0x20000


### PR DESCRIPTION
Using `imx_uart `for my project based on [phyCORE-i.MX 6UL](https://www.phytec.de/produkt/system-on-modules/phycore-imx-6-ul/)

- Fixed MSVC project file to include imx_loader_config needed for build
- Fixed` imx_sdp.c` compile error
- Added `.conf` file for i.MX6UL phytec board (probably works with other i.MX6UL boards too)
- Tested `imx_uart `to download barebox.bin to the i.MX6UL (under both Windows and Linux)

Command line needed to download over UART:
`imx_uart -n -N -d <COMport> mx6ul_uart_work.conf barebox.bin`
- i.MX6UL doesn't do the association part (so it needs to be skipped).
- It doesn't work, if a SD card is present in the i.MX system! SD card needs to be removed, or else the serial downloader isn't started (regardless of the BOOT_MODE[1:0] configuration).