### PR TITLE
add support for relocatable installs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ DESTDIR ?=
 prefix ?= /usr
 bindir ?= $(prefix)/bin
 sysconfdir ?= $(prefix)/etc
+rel_sysconfdir = $(shell realpath -m --relative-to=$(bindir) $(sysconfdir))
 
 BUILDHOST := $(shell uname -s)
 BUILDHOST := $(patsubst CYGWIN_%,CYGWIN,$(BUILDHOST))
@@ -16,7 +17,7 @@ else
 USBCFLAGS = -I/usr/include/libusb-1.0
 USBLDFLAGS = -L/usr/lib -lusb-1.0
 endif
-CONFCPPFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
+CONFCPPFLAGS = -DSYSCONFDIR='"$(sysconfdir)"' -DREL_SYSCONFDIR='"$(rel_sysconfdir)"'
 CFLAGS ?= -Wall -Wstrict-prototypes -Wno-trigraphs
 
 imx_usb.o : imx_usb.c imx_sdp.h imx_loader_config.h portable.h

--- a/imx_loader_config.c
+++ b/imx_loader_config.c
@@ -137,7 +137,7 @@ char const *conf_path_ok(char const *conf_path, char const *conf_file)
 char const *conf_file_name(char const *file, char const *base_path, char const *conf_path)
 {
 	char const *conf;
-	char cwd[PATH_MAX];
+	char path[PATH_MAX];
 
 	// First priority, conf path... (either -c, binary or /etc/imx-loader.d/)
 	dbg_printf("checking with conf_path %s\n", conf_path);
@@ -152,9 +152,16 @@ char const *conf_file_name(char const *file, char const *base_path, char const *
 		return conf;
 
 	// Third priority, working directory...
-	getcwd(cwd, PATH_MAX);
-	dbg_printf("checking with cwd %s\n", cwd);
-	conf = conf_path_ok(cwd, file);
+	getcwd(path, PATH_MAX);
+	dbg_printf("checking with cwd %s\n", path);
+	conf = conf_path_ok(path, file);
+	if (conf != NULL)
+		return conf;
+
+	// Fourth priority, conf path relative to base path...
+	snprintf(path, sizeof(path), "%s/%s", base_path, REL_SYSCONFDIR "/imx-loader.d");
+	dbg_printf("checking with rel_base_path %s\n", path);
+	conf = conf_path_ok(path, file);
 	if (conf != NULL)
 		return conf;
 


### PR DESCRIPTION
When shipping imx-usb-loader in an SDK (e.g. from Yocto), the default
configs are installed into a host-native sysroot. Add support for
such installs by checking for a config in sysconfdir relative to bindir.

Signed-off-by: Martin Hundebøll <martin@geanix.com>