### PR TITLE
Moving libusb_free_device_list to get imx_usb to work on Windows.

### DIFF
--- a/imx_usb.c
+++ b/imx_usb.c
@@ -461,7 +461,6 @@ int do_autodetect_dev(char const *base_path, char const *conf_path,
 	if (debugmode)
 		print_devs(devs);
 	dev = find_imx_dev(devs, &mach, list, bus, address);
-	libusb_free_device_list(devs, 1);
 	if (!dev) {
 		err = LIBUSB_ERROR_NO_DEVICE;
 		goto out_deinit_usb;
@@ -551,6 +550,7 @@ int do_autodetect_dev(char const *base_path, char const *conf_path,
 		if (!curr)
 			mach = mach->nextbatch;
 	}
+	libusb_free_device_list(devs, 1);
 
 out_deinit_usb:
 	libusb_exit(NULL);


### PR DESCRIPTION
From the libusb documentation, "Be careful not to unreference a device
you are about to open unitl after you opened it"
It seems all devices where unreference before libusb_open was called.
In Windows, at least, it gives a libusb error -4.
Moving the libusb_free_device_list to after libusb_open ensures
device is still referenced while trying to open.

This request fixes issue #99 