### PR TITLE
Use cfsetspeed(3) to set UART speed to fix tcsetattr: Range error

### DIFF
--- a/imx_loader_config.c
+++ b/imx_loader_config.c
@@ -216,6 +216,7 @@ void parse_mem_work(struct sdp_work *curr, const char *filename, const char *p)
 		i = MEM_TYPE_MODIFY;
 	} else {
 		printf("%s: syntax error: %s {%s}\n", filename, p, start);
+		return;
 	}
 	w.type = i;
 	i = 0;

--- a/imx_uart.c
+++ b/imx_uart.c
@@ -113,7 +113,12 @@ int uart_connect(int *uart_fd, char const *tty, int usertscts, int associate, DC
 	key.c_cflag |= CLOCAL | CREAD;
 	if (usertscts)
 		key.c_cflag |= CRTSCTS;
-	key.c_cflag |= B115200;
+	cfsetspeed(&key, B115200);
+	if (err < 0) {
+		close(*uart_fd);
+		fprintf(stdout, "cfsetspeed(%d) failed: %s\n", B115200, strerror(errno));
+		return err;
+	}
 
 	// Enable blocking read, 0.5s timeout...
 	key.c_lflag &= ~ICANON; // Set non-canonical mode
@@ -182,6 +187,7 @@ int uart_connect(int *uart_fd, char const *tty, int usertscts, int associate, DC
 
 	// Association phase, send and receive 0x23454523
 	printf("starting associating phase");
+	fflush(stdout);
 	while(retry--) {
 #ifndef WIN32
 		// Flush again before retrying


### PR DESCRIPTION
Some systems keep the speed outside of the cflags.

On FreeBSD, tcsetattr fails with ERANGE this way.