### PR TITLE
imx53: support load of single file from command line

### DIFF
--- a/imx_loader_config.c
+++ b/imx_loader_config.c
@@ -494,6 +494,10 @@ struct sdp_work *parse_cmd_args(int argc, char * const *argv)
 				i++;
 				continue;
 			}
+			if (c == 'w') {
+				w->imx53_workaround = 1;
+				continue;
+			}
 			fprintf(stderr, "Unknown option %s\n", p);
 			exit(1);
 		}

--- a/imx_sdp.h
+++ b/imx_sdp.h
@@ -51,6 +51,7 @@ struct sdp_work {
 #define J_HEADER	3
 #define J_HEADER2	4
 	unsigned char jump_mode;
+	unsigned char imx53_workaround;
 	unsigned load_addr;
 	unsigned jump_addr;
 	unsigned load_size;

--- a/imx_usb.c
+++ b/imx_usb.c
@@ -390,8 +390,10 @@ void print_usage(void)
 		"   -S --sim=VID:PID	Simulate a device of VID:PID\n"
 		"\n"
 		"And where [JOBS...] are\n"
-		"   FILE [-lLOADADDR] [-sSIZE] ...\n"
-		"Multiple jobs can be configured. The first job is treated special, load\n"
+		"   FILE [-lLOADADDR] [-sSIZE] [-w] ...\n"
+		"Multiple jobs can be configured. For each job, load address and size\n"
+		"can be specified. In addition, a workaround mode for iMX53 processors\n"
+		"can be enabled for each job. The first job is treated special, load\n"
 		"address, jump address, and length are read from the IVT header. If no job\n"
 		"is specified, the jobs defined in the target specific configuration file\n"
 		"is being used.\n");


### PR DESCRIPTION
There is some problem with the iMX53 (maybe also with others?) that
requires loading *.imx files in multiple steps: first the DCD, then load
only the binary without the header without running it and then load
everything and run it. This required adding the files to be loaded into
the configuration file, with three lines:

    foo.imx:dcd,plug
    foo.imx:load <addr>,skip <header-length>
    foo.imx:jump header2

This adds a command line option "-w" that can be used to load such a
file with one simple command:

    imx_usb foo.imx -w