### PR TITLE
imx_uart: fix option parsing on ARM and other unsigned-char systems

### DIFF
--- a/imx_uart.c
+++ b/imx_uart.c
@@ -293,7 +293,7 @@ int parse_opts(int argc, char * const *argv, char const **ttyfile,
 		char const **conffile, int *verify, int *usertscts,
 		int *associate, struct sdp_work **cmd_head)
 {
-	char c;
+	int c;
 	*conffile = NULL;
 	*ttyfile = NULL;
 


### PR DESCRIPTION
imx_uart assigns the return value of getopt_long() to a char variable.

On systems that default to unsigned char (e.g. arm, aarch64, powerpc,
s390) this causes the termination return value -1 to be read as 0xff and
the option parsing loop never terminates, causing the program to get
immediately stuck.

Fix that by using an int which is the actual return type of
getopt_long().

imx_usb already correctly uses int.

Fixes #116.

Signed-off-by: Anssi Hannula <anssi.hannula@bitwise.fi>