### PR TITLE
Fix MacOS build (include libusb.h)

### DIFF
--- a/imx_usb.c
+++ b/imx_usb.c
@@ -29,7 +29,7 @@
 #include <stdint.h>
 #include <getopt.h>
 
-#ifdef __FreeBSD__
+#if defined(__FreeBSD__) || defined(__APPLE__)
 #include <libusb.h>
 #else
 #include <libusb-1.0/libusb.h>


### PR DESCRIPTION
MacOS has behaviour on par with FreeBSD, I'm guessing. Tested on M1 Mac.
